### PR TITLE
Add Python3 support

### DIFF
--- a/chipshouter/__init__.py
+++ b/chipshouter/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["chipshouter"]
 
-from chipshouter import ChipSHOUTER
+from .chipshouter import ChipSHOUTER

--- a/chipshouter/chipshouter.py
+++ b/chipshouter/chipshouter.py
@@ -55,12 +55,12 @@
     >>> print cs #get all values of device
     >>> cs.voltage = 500
     >>> cs.pulse.width = 180
-    >>> cs.arm = 1
+    >>> cs.armed = 1
     >>> cs.pulse = 1
     >>> cs.pat_wave = [0,1,1,1,0,0,0,0,0,0,1,1,1,1,1,0]
     >>> cs.pat_enable = 1 #Turn on special pattern trigger
     >>> cs.pulse = 1
-    >>> cs.arm = False #Can use true/false or 1/0
+    >>> cs.armed = False #Can use true/false or 1/0
 
 '''
 from collections import OrderedDict

--- a/chipshouter/chipshouter.py
+++ b/chipshouter/chipshouter.py
@@ -64,9 +64,9 @@
 
 '''
 from collections import OrderedDict
-from com_tools import Bin_API
-from com_tools import Reset_Exception 
-from com_tools import Max_Retry_Exception 
+from .com_tools import Bin_API
+from .com_tools import Reset_Exception
+from .com_tools import Max_Retry_Exception
 import time
 
 api_version = '0.0.0'
@@ -957,26 +957,26 @@ def main():
     import time
     """ This is the main entry for the console."""
     cs = ChipSHOUTER('COM10')
-    print cs.status()
-    print cs.voltage
-    print 'Arming!'
+    print(cs.status())
+    print(cs.voltage)
+    print('Arming!')
     cs.mute = False
     cs.armed = True
-    print cs.voltage.set
-    print cs.voltage.measured
+    print(cs.voltage.set)
+    print(cs.voltage.measured)
     time.sleep(1)
 
     if cs.status():
-        print cs.voltage
-        print '-'*40
-        print cs.voltage.set
-        print cs.voltage.measured
+        print(cs.voltage)
+        print('-'*40)
+        print(cs.voltage.set)
+        print(cs.voltage.measured)
 
         cs.voltage.set = 205
-        print 'And... ' + str(cs.voltage)
+        print('And... ' + str(cs.voltage))
         cs.voltage = 206
-        print cs.voltage.set
-        print cs.voltage
+        print(cs.voltage.set)
+        print(cs.voltage)
     cs.armed = False 
     time.sleep(1)
     cs.disconnect()

--- a/chipshouter/com_tools.py
+++ b/chipshouter/com_tools.py
@@ -40,6 +40,9 @@
 >>>  |                         |        |                    |                            |
 
 """
+
+from __future__ import division
+
 from binascii import hexlify
 import serial
 import serial.tools.list_ports
@@ -48,8 +51,8 @@ from PyCRC.CRCCCITT import CRCCCITT
 from _socket import htonl, htons
 import pprint
 import time
-from console.serial_interface import Serial_interface
-from console.console import Console 
+from .console.serial_interface import Serial_interface
+from .console.console import Console
 
 class Firmware_State_Exception(Exception):
     pass
@@ -61,7 +64,7 @@ class Reset_Exception(Exception):
     pass
 
 class Connection(object):
-    START_UP_STRING = 'ChipShouter by NewAE Technology Inc.'
+    START_UP_STRING = b'ChipShouter by NewAE Technology Inc.'
 
     def __init__(self, comport, logging = False):
         self.comport = comport
@@ -116,8 +119,8 @@ class Connection(object):
             except Exception as e:
                 print("Could not read from port" + str(e))
 
-            start = data.find('\x7e')
-            end   = data.find('\x7f')
+            start = data.find(b'\x7e')
+            end   = data.find(b'\x7f')
 
             txt_start = ''
             txt_end   = ''
@@ -204,7 +207,7 @@ class Option_group(object):
 
         """
         bit_array = bytearray()
-        bits_array_length = (limit) / 8
+        bits_array_length = (limit) // 8
 
         for x in range(bits_array_length):
             bit_array.append(0)
@@ -213,7 +216,7 @@ class Option_group(object):
         for x in range(limit): 
             # set the bits
             if bools[x]['value'] == True:
-                index = x/8
+                index = x//8
                 bit   = x % 8 
                 bit_array[index] |= 1 << bit 
 
@@ -563,14 +566,14 @@ class BP_TOOL(Connection):
     def set_options_requested(self, options):
         max_value = max(options)
         bit_array = bytearray()
-        bits_array_length = max_value / 8 + 1
+        bits_array_length = max_value // 8 + 1
 
         for x in range(bits_array_length):
             bit_array.append(0)
 
         for x in options:
             # set the bits
-            index = x/8
+            index = x//8
             bit   = x % 8 
             bit_array[index] |= 1 << bit 
 
@@ -671,9 +674,9 @@ class BP_TOOL(Connection):
 
     def build_request_all(self):
         packet = bytearray()
-        packet.append(int(t_16_Bit_Options.MAX / 8 + 1))
-        packet.append(int(t_8_Bit_Options.MAX / 8 + 1))
-        packet.append(int(t_var_size_Options.MAX / 8 + 1))
+        packet.append(int(t_16_Bit_Options.MAX // 8 + 1))
+        packet.append(int(t_8_Bit_Options.MAX // 8 + 1))
+        packet.append(int(t_var_size_Options.MAX // 8 + 1))
 
         # ---------------------------------------------------------------------
         # Request all the 16 bit options.
@@ -765,98 +768,98 @@ class BP_TOOL(Connection):
         t_16   = t_16_Bit_Options()
         t_8    = t_8_Bit_Options()
         t_var  = t_8_Bit_Options()
-        print 'Received ' + str(len(data)) + ' Bytest'
+        print('Received ' + str(len(data)) + ' Bytest')
 
         #----------------------------------------------------------------------
-        print '='*80
-        print 'Handling Protocol response: ' + hexlify(data)
+        print('='*80)
+        print('Handling Protocol response: ' + hexlify(data))
         #----------------------------------------------------------------------
-        print '='*80
-        print 'Overhead Bytes: ' + hexlify(data[:BP_TOOL.OVERHEAD])
-        print 'Number of UINT16 bitstream data = ' + str(data[BP_TOOL.UINT16S])
-        print 'Number of UINT8  bitstream data = ' + str(data[BP_TOOL.UINT8S])
-        print 'Number of var    bitstream data = ' + str(data[BP_TOOL.VARS])
-        print 'Follow = ' + str(self.get_follow(data))
-        print 'Length = ' + str(self.get_length(data))
+        print('='*80)
+        print('Overhead Bytes: ' + hexlify(data[:BP_TOOL.OVERHEAD]))
+        print('Number of UINT16 bitstream data = ' + str(data[BP_TOOL.UINT16S]))
+        print('Number of UINT8  bitstream data = ' + str(data[BP_TOOL.UINT8S]))
+        print('Number of var    bitstream data = ' + str(data[BP_TOOL.VARS]))
+        print('Follow = ' + str(self.get_follow(data)))
+        print('Length = ' + str(self.get_length(data)))
         start = self.get_follow_and_length(data)
         end   = start + BP_TOOL.SIZE_FOLLOW + BP_TOOL.SIZE_LEN
-        print 'Following bytes and length      = ' + hexlify(data[start:end])
+        print('Following bytes and length      = ' + hexlify(data[start:end]))
         #----------------------------------------------------------------------
-        print '='*80
+        print('='*80)
         bits = self.get_16bit_options_bits(data)
         values = self.get_16bit_options(data)
         options = self.get_options_requested(bits)
 
         # Display the options if exist
         if len(options):
-            print 'UINT16 bits...... : ' + hexlify(bits)
-            print 'UINT16 data...... : ' + hexlify(values)
-            print 'UINT16 Num of opts ... : ' + str(len(values) / 2)
-            print 'UINT16 options... : ' + str(options)
-            print '-'*80
+            print('UINT16 bits...... : ' + hexlify(bits))
+            print('UINT16 data...... : ' + hexlify(values))
+            print('UINT16 Num of opts ... : ' + str(len(values) // 2))
+            print('UINT16 options... : ' + str(options))
+            print('-'*80)
             for x in range(len(options)):
                 value = (values[x*2] << 8) | (values[x*2 + 1])
                 opt = options[x]
                 t_16.set_value(opt, value)
-                print 'Option: ' + t_16.options[opt]['name'] + ' ' + str(value)
+                print('Option: ' + t_16.options[opt]['name'] + ' ' + str(value))
             pprint.pprint(t_16.options)
         else:
-            print 'No 16 bit options'
+            print('No 16 bit options')
 
         #----------------------------------------------------------------------
-        print '-'*80
+        print('-'*80)
         bits = self.get_8bit_options_bits(data)
         values = self.get_8bit_options(data)
         options = self.get_options_requested(bits)
         # Display the options if exist
         if len(options):
-            print 'UINT8 bits...... : ' + hexlify(bits)
-            print 'UINT8 data...... : ' + hexlify(values)
-            print 'UINT8 options... : ' + str(options)
-            print '-'*80
+            print('UINT8 bits...... : ' + hexlify(bits))
+            print('UINT8 data...... : ' + hexlify(values))
+            print('UINT8 options... : ' + str(options))
+            print('-'*80)
             for x in range(len(options)):
                 value = values[x]
                 opt = options[x]
                 t_8.set_value(opt, value)
-                print 'Option: ' + t_8.options[x]['name'] + ' ' + str(value)
+                print('Option: ' + t_8.options[x]['name'] + ' ' + str(value))
             pprint.pprint(t_8.options)
         else:
-            print 'No 8 bit options'
+            print('No 8 bit options')
 
         #----------------------------------------------------------------------
-        print '-'*80
+        print('-'*80)
         bits = self.get_var_options_bits(data)
         values = self.get_var_options(data)
-        print 'VARS !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'
+        print('VARS !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!')
         # Display the options if exist
         if len(values):
             pprint.pprint(values)
         else:
-            print 'No var bit options'
+            print('No var bit options')
 
-        print 'VAR options... : ' + str(self.get_options_requested(bits))
-        print 'VARS !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'
-        print '-'*80
+        print('VAR options... : ' + str(self.get_options_requested(bits)))
+        print('VARS !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!')
+        print('-'*80)
 
     def display_options(self):
-        print 'Options'
-        print '='*80
-        print '16 bit options'
-        print '='*80
+        print('Options')
+        print('='*80)
+        print('16 bit options')
+        print('='*80)
         pprint.pprint(self.config_16.options)
-        print 'Current Faults'
-        print '='*80
+        print('Current Faults')
+        print('='*80)
         pprint.pprint(self.config_16.faults_current)
-        print 'Latched Faults'
-        print '='*80
+        print('Latched Faults')
+        print('='*80)
         pprint.pprint(self.config_16.faults_latched)
-        print '8 bit options'
-        print '='*80
+        print('8 bit options')
+        print('='*80)
         pprint.pprint(self.config_8.options)
-        print 'bool options'
-        print '='*80
+        print('bool options')
+        print('='*80)
         pprint.pprint(self.config_8.bools)
-        print '-'*80
+        print('-'*80)
 
 class Protocol(BP_TOOL):
     """
@@ -1019,11 +1022,11 @@ class Protocol(BP_TOOL):
 
     def __show_data(self, data, ask = True):
         if ask:
-            print 'Requesting: ' + ' ' + hexlify(data)
-        print 'BP_TOOL.OVERHEAD) ' + str(BP_TOOL.OVERHEAD)
-        print '[BP_TOOL.UINT16S] ' + str(data[BP_TOOL.UINT16S])
-        print '[BP_TOOL.UINT8S]) ' + str(data[BP_TOOL.UINT8S])
-        print '[BP_TOOL.VARS     ' + str(data[BP_TOOL.VARS])
+            print('Requesting: ' + ' ' + hexlify(data))
+        print('BP_TOOL.OVERHEAD) ' + str(BP_TOOL.OVERHEAD))
+        print('[BP_TOOL.UINT16S] ' + str(data[BP_TOOL.UINT16S]))
+        print('[BP_TOOL.UINT8S]) ' + str(data[BP_TOOL.UINT8S]))
+        print('[BP_TOOL.VARS     ' + str(data[BP_TOOL.VARS]))
         pass
 
     def __is_nack(self, data):
@@ -1141,7 +1144,7 @@ class Bin_API(Protocol):
         :returns (String): name of the board programmed at time of assembly. 
         """
         self.get_option_from_shouter([t_var_size_Options.BOARD_ID], BP_TOOL.REQUEST_VAR)
-        return str(self.config_var.options[t_var_size_Options.BOARD_ID]['value'])
+        return str(self.config_var.options[t_var_size_Options.BOARD_ID]['value'].decode("ASCII"))
 
     def get_id(self, timeout = 0):
         return self.get_board_id()
@@ -1152,7 +1155,7 @@ class Bin_API(Protocol):
         :returns (String): string of the state.
         """
         self.get_option_from_shouter([t_var_size_Options.CURRENT_STATE], BP_TOOL.REQUEST_VAR)
-        rval = str(self.config_var.options[t_var_size_Options.CURRENT_STATE]['value'])
+        rval = str(self.config_var.options[t_var_size_Options.CURRENT_STATE]['value'].decode("ASCII"))
         return rval
 
     def get_is_reset(self, timeout = 0):
@@ -1392,7 +1395,7 @@ class Bin_API(Protocol):
     def set_pat_wave(self, value, timeout = 0):
         wave = value
         bit_array = bytearray()
-        bits_array_length = (len(wave)) / 8
+        bits_array_length = (len(wave)) // 8
 
         if len(wave) % 8:
             bits_array_length += 1
@@ -1405,10 +1408,10 @@ class Bin_API(Protocol):
 
         index = 0
         for x in wave: 
-            if x == '1':
-                bit_array[index / 8] |= (0x80 >> (index % 8))
+            if x == '1' or x == 1:
+                bit_array[index // 8] |= (0x80 >> (index % 8))
                 pass
-            elif x == '0':
+            elif x == '0' or x == 0:
                 pass
             else:
                 raise ValueError('Only \'1\' an \'0\' allowed')
@@ -1423,7 +1426,7 @@ class Bin_API(Protocol):
             send = bit_array[x:(x + max_bytes_packet)]
             send_bits_length = max_bits_packet
 
-            if (((x / max_bytes_packet) + 1) * (max_bits_packet)) > len(wave):
+            if (((x // max_bytes_packet) + 1) * (max_bits_packet)) > len(wave):
                 send_bits_length = len(wave) % (max_bits_packet)
 
             total_bit_count += send_bits_length
@@ -1461,13 +1464,13 @@ class Bin_API(Protocol):
         my_console = Console(serial, threads = False)
         my_console.console()
         self.ctl_connect()
-        print 'Console Complete'
+        print('Console Complete')
 
 ################################################################################
 def main():
     """ This is the main entry for the console."""
     bp = Bin_API('COM10')
-    print 'Testing'
+    print('Testing')
 
     bp.set_hwtrig_term(1)
 

--- a/chipshouter/console/console.py
+++ b/chipshouter/console/console.py
@@ -22,7 +22,7 @@ from chipshouter.console.download import cs_dl
 try:
     from tqdm import tqdm
 except Exception as e:
-    print e
+    print(e)
 
 #sys.settrace
 #---------------------------------------------------------------------------
@@ -50,11 +50,11 @@ class Console():
     #---------------------------------------------------------------------------
     def mod_sendfile(self):
         """ This will reset the board .. used from the menu. """
-        print 'Current file: ' + self.sendfile
-        newfile = raw_input("Enter new relative filename: ")
+        print('Current file: ' + self.sendfile)
+        newfile = input("Enter new relative filename: ")
         if len(newfile):
             self.sendfile = newfile
-        print 'Console is now using: ' + self.sendfile
+        print('Console is now using: ' + self.sendfile)
 
     #---------------------------------------------------------------------------
     def reset(self):
@@ -77,14 +77,14 @@ class Console():
     #---------------------------------------------------------------------------
     def print_menu(self):
         """ Prints the menu. """
-        print "------------------------------------------------------------"
-        print " The following SPECIAL COMMANDS are not sent to the         "
-        print " ChipSHOUTER over the serial port, but are instead processed"
-        print " by this Python application:                                 "
+        print("------------------------------------------------------------")
+        print(" The following SPECIAL COMMANDS are not sent to the         ")
+        print(" ChipSHOUTER over the serial port, but are instead processed")
+        print(" by this Python application:                                 ")
         for x in self.menu:
-            print '    {:<10}'.format(x['input']) + '- ' + x['help']
-        print "If none of these it will send to the board what you type."
-        print "------------------------------------------------------------"
+            print('    {:<10}'.format(x['input']) + '- ' + x['help'])
+        print("If none of these it will send to the board what you type.")
+        print("------------------------------------------------------------")
 
     #---------------------------------------------------------------------------
     def quit(self):
@@ -106,7 +106,7 @@ class Console():
         self.serial.s_init(self.rx_callback)
         while not self.stop:
             send_to_shouter = True
-            data = raw_input("")
+            data = input("")
             for x in self.menu:
                 if x['input'] == data:
                     send_to_shouter = False
@@ -125,25 +125,25 @@ class Console():
     #---------------------------------------------------------------------------
     def verify(self):
         """ This will download the send file to the shouter. """
-        print '*'*30
-        print 'Stage 1 Downloading'
-        print '*'*30
+        print('*'*30)
+        print('Stage 1 Downloading')
+        print('*'*30)
         if self.download(verify = True):
-            print '*'*30
-            print 'Stage 2 Downloading'
-            print '*'*30
+            print('*'*30)
+            print('Stage 2 Downloading')
+            print('*'*30)
             checkstring = 'ChipShouter by NewAE Technology Inc.'
             rval = self.download(checkstring = checkstring)
             if checkstring in rval:
-                print 'Good download'
+                print('Good download')
             else:
                 raise ValueError('Error App did not start')
-                print 'Error with downloading file'
-                print '*'*30
+                print('Error with downloading file')
+                print('*'*30)
         else:
             raise ValueError('Error with downloading file')
-            print 'Error with downloading file'
-            print '*'*30
+            print('Error with downloading file')
+            print('*'*30)
 
     #---------------------------------------------------------------------------
     def download(self, verify = False, checkstring = None, break_crc = False, break_frame = False):
@@ -157,7 +157,7 @@ class Console():
 #        if self.rx_timer:
         self.rx_timer.cancel()
 
-        print 'Sending: ' + self.sendfile
+        print('Sending: ' + self.sendfile)
         if self.threads == True:
             dnld = cs_dl(self.serial.s_write)
         else:
@@ -171,7 +171,7 @@ class Console():
         for x in range(2):
             # Reset the board
             self.serial.s_write('s bb 0\n')
-            print 'Sending reset for download .... [' + str(x) + ']'
+            print('Sending reset for download .... [' + str(x) + ']')
             self.serial.s_write('reset\n')
             response = dnld.wait_for_ack(4)
             if response == b'\x16':
@@ -186,14 +186,14 @@ class Console():
         
         # Download the file
         try:
-            for i in tqdm(range(filesize), ascii = True, desc = 'Downloading'):
+            for i in tqdm(list(range(filesize)), ascii = True, desc = 'Downloading'):
                 rval = dnld.send_packet(file_tx, packet, break_crc = break_crc, break_frame = break_frame)
                 if rval == 0:
                     raise ValueError('Error with downloading file')
                     return '' 
                 packet += 1
         except Exception as e:
-            print e
+            print(e)
             try:
                 for i in range(filesize):
                     val_percent = i*100/filesize
@@ -205,8 +205,8 @@ class Console():
                         return '' 
                     packet += 1
             except Exception as e:
-                print 'download without tqdm'
-                print e
+                print('download without tqdm')
+                print(e)
                 raise
 
             self.stop = True
@@ -267,7 +267,7 @@ def main():
     if args.sendfile:
         sendfile = args.sendfile
     if args.threads:
-        print 'Using threads'
+        print('Using threads')
         threads = True
         wait_callback = None
     else:
@@ -300,7 +300,7 @@ def main():
         elif args.test_frame:
             my_console.test_frame()
         elif args.checkstring:
-            print 'Checking for ' + args.checkstring
+            print('Checking for ' + args.checkstring)
             rval = my_console.download(checkstring = args.checkstring)
             if args.checkstring not in rval:
                 raise ValueError('Did not verify' + args.checkstring)

--- a/chipshouter/console/console.py
+++ b/chipshouter/console/console.py
@@ -24,6 +24,8 @@ try:
 except Exception as e:
     print(e)
 
+import six
+
 #sys.settrace
 #---------------------------------------------------------------------------
 class Console():
@@ -51,7 +53,7 @@ class Console():
     def mod_sendfile(self):
         """ This will reset the board .. used from the menu. """
         print('Current file: ' + self.sendfile)
-        newfile = input("Enter new relative filename: ")
+        newfile = six.moves.input("Enter new relative filename: ")
         if len(newfile):
             self.sendfile = newfile
         print('Console is now using: ' + self.sendfile)
@@ -95,7 +97,7 @@ class Console():
     def display_rx(self, data):
         """ Display what was received, this is the intended callback for rx serial.
         """
-        sys.stdout.write(data)
+        sys.stdout.write(data.decode("ASCII"))
 
     #---------------------------------------------------------------------------
     def console(self):
@@ -106,7 +108,7 @@ class Console():
         self.serial.s_init(self.rx_callback)
         while not self.stop:
             send_to_shouter = True
-            data = input("")
+            data = six.moves.input("")
             for x in self.menu:
                 if x['input'] == data:
                     send_to_shouter = False

--- a/chipshouter/console/download.py
+++ b/chipshouter/console/download.py
@@ -130,7 +130,7 @@ class cs_dl():
         try:
             f = open(my_file, "rb")
         except:
-            print("Error opening " + my_file)
+            print(("Error opening " + my_file))
             return ''
         try:
             byte = f.read(1)
@@ -149,8 +149,8 @@ class cs_dl():
         try:
             end = file_tx.find('\x7f') + 1
         except Exception as e:
-            print 'Error with the file'
-            print e
+            print('Error with the file')
+            print(e)
             return 0
         while end > 0:
             packets += 1
@@ -196,7 +196,7 @@ class cs_dl():
                 end     = file_tx.find('\x7f') + 1
                 start   = file_tx.find('\x7e')
                 tx_packet = file_tx[start:end]
-        print 'Returning'
+        print('Returning')
         return 0
 
     #---------------------------------------------------------------------------
@@ -229,7 +229,7 @@ class cs_dl():
         """
         if self.__print_rx_details:
             if len(data):
-                print 'rx: ' + hexlify(data)
+                print('rx: ' + hexlify(data))
 
         # This -----------------------------------------------------------------
         # Copy received to the buffer.
@@ -251,7 +251,7 @@ class cs_dl():
             start = self.__rx_buffer[:end].rfind('\x7e')
             self.buff.add(self.packet_unstuff(self.__rx_buffer[start:end + 1]))
             if self.__print_rx:
-                print("PACKET!!: " + hexlify(self.__rx_buffer[start:end + 1]))
+                print(("PACKET!!: " + hexlify(self.__rx_buffer[start:end + 1])))
 
             self.__rx_buffer = self.__rx_buffer[end + 1:]
             start = self.__rx_buffer.find('\x7e')

--- a/chipshouter/console/serial_interface.py
+++ b/chipshouter/console/serial_interface.py
@@ -158,7 +158,7 @@ class Serial_interface(object):
         """
         if self.s.is_open:
             try:
-                self.s.write(data)
+                self.s.write(data.encode("ASCII"))
             except:
                 print("Could not write to port")
         else:

--- a/chipshouter/console/serial_interface.py
+++ b/chipshouter/console/serial_interface.py
@@ -6,7 +6,7 @@ This is the file to handle the serial interfaces.
 """
 #---------------------------------------------------------------------------
 
-import Queue
+import queue
 from threading import Thread
 import serial
 import serial.tools.list_ports
@@ -20,8 +20,8 @@ class Serial_interface(object):
         self.__rx_callback  = None 
 
         if self.use_thread:
-            self.__rx_queue = Queue.Queue() 
-            print 'Starting serial with threads'
+            self.__rx_queue = queue.Queue()
+            print('Starting serial with threads')
 
     def __thread_run_rx(self):
         """ This will scan the quit attribute to see  if we need to disconnect and 
@@ -67,7 +67,7 @@ class Serial_interface(object):
                     except Exception as e: 
                         print(e)
                         print("Bad callback in rx")
-                except Queue.Empty:
+                except queue.Empty:
                     pass
             time.sleep(.02)
         print("Exiting serial_rx Thread because I was told")
@@ -128,7 +128,7 @@ class Serial_interface(object):
                 self.__serial_rx_app_handle_thread.start()
             
         except Exception as err:
-            print err
+            print(err)
             connected = False
         return(connected)
 
@@ -205,9 +205,9 @@ user_input = ''
 def scan_input():
     global user_input
     while True:
-        user_input = raw_input("scan_input:")
+        user_input = input("scan_input:")
         if user_input == 'quit':
-            print 'Got quit exiting'
+            print('Got quit exiting')
             break
     pass
 
@@ -235,37 +235,37 @@ def main():
 
     #----------------------------------------------------------------------------
     #--- Start the Shouter API 
-    data = raw_input("Yes for threading Otherwise select no:")
+    data = input("Yes for threading Otherwise select no:")
     if data.lower() == 'yes':
-        print '-------------------------'
-        print 'Testing Threading version'
-        print '-------------------------'
+        print('-------------------------')
+        print('Testing Threading version')
+        print('-------------------------')
         st = Serial_interface()
         st.s_init(test_rx)
         if st.s_open(port) == True:
-            print 'Connected to comport:'
+            print('Connected to comport:')
             data = ''
             while True:
-                data = raw_input("")
+                data = input("")
                 if data == 'quit':
                     break
                 st.s_write(data)
                 st.s_write('\n')
             st.s_close()
         else:
-            print 'Can not Connect:'
+            print('Can not Connect:')
     else:
-        print '-------------------------'
-        print 'Testing NON Threading version'
-        print '-----------------------------'
+        print('-------------------------')
+        print('Testing NON Threading version')
+        print('-----------------------------')
         st = Serial_interface(use_thread = False)
         st.s_init(test_rx)
         if st.s_open(port) == True:
-            print 'Connected to comport:'
+            print('Connected to comport:')
             data = ''
             input_thread  = Thread(target = scan_input)
             input_thread.start()
-            print 'Wait for input:'
+            print('Wait for input:')
 
             #--------------------------------
             while True:
@@ -273,7 +273,7 @@ def main():
                 if len(data):
                     if data == 'quit':
                         break
-                    print 'Writing data: ' + data
+                    print('Writing data: ' + data)
                     st.s_write(data)
                     st.s_write('\n')
                 else:
@@ -283,7 +283,7 @@ def main():
             #--------------------------------
             st.s_close()
         else:
-            print 'Can not Connect:'
+            print('Can not Connect:')
         pass
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ PyCRC==1.21
 
 # Require future only for Python2
 future ; python_version < '3'
+# Require six for a (Pylint compatible) way to have a
+# portable input()
+six

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 pyserial==3.4
 PyCRC==1.21
+
+# Require future only for Python2
+future ; python_version < '3'


### PR DESCRIPTION
This commit adds Python3 support to the ChipSHOUTER Python API.

Compatibility to Python2 was retained by adding the `future` package into requirements.txt for Python2 - this module is only needed to support `import queue` (which used to be `import Queue` in Python2).

I tested this against the example code, however I have not yet tested things like firmware updates.