### PR TITLE
Remove PyCRC dependency (broken in Python3) and use local implementation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 pyserial==3.4
-PyCRC==1.21
 
 # Require future only for Python2
 future ; python_version < '3'

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ setup(
     scripts=['scripts/shouter-console.py'],
     install_requires = [
         'pyserial',
-        'PyCRC',\
         'tqdm'
     ],
 )


### PR DESCRIPTION
ChipSHOUTERr-python has in its requirements PyCRC==1.21

But with Python3, installing requirements pulls https://pypi.org/project/pycrc/ which is another implementation (https://pycrc.org/ v0.9.2)
Moreover, the PyCRC used in ChipSHOUTER is GPLv3, incompatible with ChipSHOUTER MIT license.
I chose to reimplement the required CRC snipped, based on https://stackoverflow.com/a/25259157 which implements the same logic as is PyCRC (obviously, there aren't many ways to implement a given CRC...).

The code is still compatible both for Python2.7 and Python3.
