### PR TITLE
send write_nvm command before reset shouter (firmware update)

### DIFF
--- a/chipshouter/console/console.py
+++ b/chipshouter/console/console.py
@@ -193,6 +193,7 @@ class Console():
         for x in range(2):
             # Reset the board
             self.serial.s_write('s bb 0\n')
+            self.serial.s_write('write_nvm\n')
             print('Sending reset for download .... [' + str(x) + ']')
             self.serial.s_write('reset\n')
             response = dnld.wait_for_ack(10)


### PR DESCRIPTION
At least ChipShouter 2.0.1 will not go into download mode unless you send `write_nvm` after setting bootbits to 0.

## without `write_nvm`

```
# disarmed:set bb 0
size auto commands 45# bootbits                                  0 Decimal ........[Boot bits]

# disarmed:reset

ChipShouter by NewAE Technology Inc.
```

## with `write_nvm`

```
# disarmed:set bb 0
size auto commands 45# bootbits                                  0 Decimal ........[Boot bits]

# disarmed:write_nvm
size auto commands 45# write_nvm

# disarmed:reset
<devid>~
ChipShouter by NewAE Technology Inc.
```

With the previous code, firmware update fails.

```
$ python3 ./shouter-console.py --download ../../firmware/cw520_<devid>_2-0-2_firmware.fup /dev/ttyUSB0 
Connected successful
Sending: ../../firmware/cw520_<devid>_2-0-2_firmware.fup
Checking board ID...
Board ID matches file.
Attempting reset - you may need to power cycle ChipSHOUTER NOW with some versions.
You will hear ChipSHOUTER reset, but sometimes you need power cycle to allow update.
Sending reset for download .... [0]
Sending reset for download .... [1]
Traceback (most recent call last):
  File "./shouter-console.py", line 5, in <module>
    main()
  File "/home/user/tools/emfi/venv/lib/python3.8/site-packages/chipshouter/console/console.py", line 332, in main
    my_console.download()
  File "/home/user/tools/emfi/venv/lib/python3.8/site-packages/chipshouter/console/console.py", line 205, in download
    raise ValueError('Downloading did not receive response from the shouter')
ValueError: Downloading did not receive response from the shouter
```

Therefore, I added code to send the write_nvm command before reset.